### PR TITLE
fix auto-wiring bug

### DIFF
--- a/src/main/java/org/mentacontainer/impl/MentaContainer.java
+++ b/src/main/java/org/mentacontainer/impl/MentaContainer.java
@@ -430,7 +430,11 @@ public class MentaContainer implements Container {
 		
 		String s = InjectionUtils.getKeyName(sourceFromContainer);
 		
-		autowireBySetter(s);
+		// ATTENTION: targetProperty needs to be adjusted when sourceFromContainer is a class
+		
+		String targetProperty = InjectionUtils.getTargetPropertyName(sourceFromContainer);
+		
+		autowireBySetter(targetProperty, s);
 		
 		autowireByConstructor(s);
 	}
@@ -454,11 +458,6 @@ public class MentaContainer implements Container {
 		SetterDependency d = new SetterDependency(targetProperty, sourceFromContainer, sourceType);
 		
 		setterDependencies.add(d);
-	}
-	
-	private void autowireBySetter(String targetProperty) {
-		
-		autowireBySetter(targetProperty, targetProperty);
 	}
 	
 	private void autowireByConstructor(String sourceFromContainer) {

--- a/src/main/java/org/mentacontainer/util/InjectionUtils.java
+++ b/src/main/java/org/mentacontainer/util/InjectionUtils.java
@@ -363,6 +363,20 @@ public class InjectionUtils {
 		}
 		return obj.toString();
 	}
+	
+	public static String getTargetPropertyName(Object obj) {
+		if (obj instanceof Class<?>) {
+			Class<?> k = (Class<?>) obj;
+			String s = k.getSimpleName();
+			StringBuilder sb = new StringBuilder(s.length());
+			sb.append(s.substring(0, 1).toLowerCase());
+			if (s.length() > 1) {
+				sb.append(s.substring(1));
+			}
+			return sb.toString();
+		}
+		return obj.toString();
+	}
 
 	public static Method findMethodToGet(Class<?> target, String name) {
 


### PR DESCRIPTION
Auto-wiring need the correct beanProperty name to inject... It can't receive `org.blah.Bean` but `bean` so the method `setBean` can be found for the injection.
