### PR TITLE
fix auto-wire bug with inject method

### DIFF
--- a/src/main/java/org/mentacontainer/impl/MentaContainer.java
+++ b/src/main/java/org/mentacontainer/impl/MentaContainer.java
@@ -494,6 +494,20 @@ public class MentaContainer implements Container {
 		
 		return t;
 	}
+	
+	private String getAutowireKey(String key) {
+		
+		for(SetterDependency sd: setterDependencies) {
+			
+			String targetProperty = sd.getTarget();
+			
+			if (key.equals(targetProperty)) {
+				return sd.getSource();
+			}
+		}
+		
+		return key;
+	}
 
 	@Override
 	public void inject(Object bean) {
@@ -503,11 +517,15 @@ public class MentaContainer implements Container {
 			@Override
 			public Object get(String key) {
 				
+				key = getAutowireKey(key);
+				
 				return MentaContainer.this.get(key);
 			}
 			
 			@Override
 			public boolean hasValue(String key) {
+				
+				key = getAutowireKey(key);
 				
 				return MentaContainer.this.check(key);
 			}


### PR DESCRIPTION
inject method was not taking into account the auto-wiring configuration so when you were defining the beanProperty in the `autowire` method, it was being ignored.
